### PR TITLE
Add netsh command to record a network trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Tools and resources used by PFEs
     ```powershell
     netsh trace stop
     ```
+    Dont't forget to change the parser in Netmon in order to properly do the analysis
 
 ## [Chocolatey](https://chocolatey.org/)
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,19 @@ Tools and resources used by PFEs
   * [TCPView](https://download.sysinternals.com/files/TCPView.zip) - [Docs](https://docs.microsoft.com/en-us/sysinternals/downloads/tcpview)
 * [Log Parser Studio](https://gallery.technet.microsoft.com/Log-Parser-Studio-cd458765)
 * [Performance Analysis of Logs (PAL) tool](https://github.com/clinthuffman/PAL/releases)
+* [Netmon](https://www.microsoft.com/en-us/download/details.aspx?id=4865)
+
+## [Capture a Network Trace without installing anything](https://blogs.msdn.microsoft.com/canberrapfe/2012/03/30/capture-a-network-trace-without-installing-anything-capture-a-network-trace-of-a-reboot/)
+
+* Command
+
+    ```powershell
+    netsh trace start persistent=yes capture=yes tracefile=c:\temp\nettrace-boot.etl
+    ```
+    After reproduce the problem, stop the tracing
+    ```powershell
+    netsh trace stop
+    ```
 
 ## [Chocolatey](https://chocolatey.org/)
 


### PR DESCRIPTION
Added a way to record a network trace without installing any tool. 
The generated trace can be then analyzed with Netmon.

Reference: https://blogs.msdn.microsoft.com/canberrapfe/2012/03/30/capture-a-network-trace-without-installing-anything-capture-a-network-trace-of-a-reboot/